### PR TITLE
Table Pagination Callback Argument Update

### DIFF
--- a/src/components/pagination/Pagination.jsx
+++ b/src/components/pagination/Pagination.jsx
@@ -162,7 +162,13 @@ const Pagination = ({
             !canPreviousPage ? ' ce-arrow--disabled' : ''
           }`}
         >
-          <button disabled={!canPreviousPage} onClick={prevPage} type="button">
+          <button
+            disabled={!canPreviousPage}
+            onClick={prevPage}
+            title="Previous Page"
+            type="button"
+            aria-label="Previous Page"
+          >
             <SystemIcon name="navigate" color="black" />
           </button>
         </li>
@@ -172,7 +178,13 @@ const Pagination = ({
             !canNextPage ? ' ce-arrow--disabled' : ''
           }`}
         >
-          <button disabled={!canNextPage} onClick={nextPage} type="button">
+          <button
+            disabled={!canNextPage}
+            onClick={nextPage}
+            title="Next Page"
+            type="button"
+            aria-label="Next Page"
+          >
             <SystemIcon name="navigate" color="black" />
           </button>
         </li>
@@ -196,8 +208,6 @@ Pagination.propTypes = {
   className: PropTypes.string,
   /**
    * The current page number.
-   *
-   * NOTE: Due to interactions between `<Pagination />` and `<Table />` this is 0-indexed.
    */
   currentPage: PropTypes.number.isRequired,
   /**

--- a/src/components/pagination/Pagination.jsx
+++ b/src/components/pagination/Pagination.jsx
@@ -32,7 +32,7 @@ const Pagination = ({
   className,
   canNextPage,
   canPreviousPage,
-  currentPage, // 0-indexed
+  currentPage,
   gotoPage,
   nextPage,
   pageCount,
@@ -42,85 +42,81 @@ const Pagination = ({
 
   const renderNumbers = () => {
     const elements = [];
-    const realPage = currentPage + 1;
 
     if (pageCount > 5) {
       for (let i = 1; i < 6; i++) {
         let classList = 'ce-pagination__number';
         let label = '...';
-        let navToPage; // because currentPage is 0 indexed, so is this
+        let navToPage;
 
         switch (i) {
           case 1:
             label = 1;
-            navToPage = 0;
+            navToPage = 1;
 
-            if (realPage === 1) classList = `${classList} current-page`;
+            if (currentPage === 1) classList = `${classList} current-page`;
             break;
           case 2:
-            if (realPage <= 3) {
+            if (currentPage <= 3) {
               label = 2;
-              navToPage = 1;
+              navToPage = 2;
             }
 
-            if (realPage === 2) {
+            if (currentPage === 2) {
               classList = `${classList} current-page`;
             }
 
-            if (realPage > 3) {
+            if (currentPage > 3) {
               label = '...';
               navToPage = currentPage - 1;
             }
             break;
           case 3:
-            if (realPage <= 3) {
+            if (currentPage <= 3) {
               label = 3;
-              navToPage = 2;
+              navToPage = 3;
             }
 
-            if (realPage === 3) classList = `${classList} current-page`;
+            if (currentPage === 3) classList = `${classList} current-page`;
 
-            if (realPage > 3 && realPage < pageCount - 1) {
-              label = realPage;
+            if (currentPage > 3 && currentPage < pageCount - 1) {
+              classList = `${classList} current-page`;
+              label = currentPage;
               navToPage = currentPage;
             }
 
-            if (realPage > 3 && realPage < pageCount - 1) {
-              classList = `${classList} current-page`;
-            }
-
-            if (realPage === pageCount - 1 || realPage === pageCount) {
+            if (currentPage === pageCount - 1 || currentPage === pageCount) {
               label = pageCount - 2;
-              navToPage = pageCount - 3;
+              navToPage = pageCount - 2;
             }
             break;
           case 4:
-            if (realPage < pageCount - 2) {
+            if (currentPage < pageCount - 2) {
               label = '...';
               navToPage = currentPage + 1;
             }
 
-            if (realPage === pageCount - 2) {
-              label = realPage + 1;
+            if (currentPage === pageCount - 2) {
+              label = currentPage + 1;
               navToPage = currentPage + 1;
             }
 
-            if (realPage === pageCount - 1) {
+            if (currentPage === pageCount - 1) {
               classList = `${classList} current-page`;
-              label = realPage;
+              label = currentPage;
               navToPage = currentPage;
             }
 
-            if (currentPage + 1 === pageCount) {
+            if (currentPage === pageCount) {
               label = pageCount - 1;
-              navToPage = pageCount - 2;
+              navToPage = pageCount - 1;
             }
             break;
           case 5: // extreme right
             label = pageCount;
-            navToPage = pageCount - 1;
+            navToPage = pageCount;
 
-            if (currentPage + 1 === pageCount) {
+            if (currentPage === pageCount) {
               classList = `${classList} current-page`;
             }
             break;
@@ -139,7 +135,7 @@ const Pagination = ({
         );
       }
     } else {
-      for (let i = 0; i < pageCount; i++) {
+      for (let i = 1; i <= pageCount; i++) {
         elements.push(
           <li
             className={`ce-pagination__number${
@@ -147,11 +143,8 @@ const Pagination = ({
             }`}
             key={i}
           >
-            <button
-              type="button"
-              onClick={() => gotoPage(i) /* The pages are 0-indexed */}
-            >
-              {i + 1}
+            <button type="button" onClick={() => gotoPage(i)}>
+              {i}
             </button>
           </li>,
         );

--- a/src/components/pagination/Pagination.stories.mdx
+++ b/src/components/pagination/Pagination.stories.mdx
@@ -6,7 +6,7 @@ import {
   Story,
 } from '@storybook/addon-docs/blocks';
 import { action } from '@storybook/addon-actions';
-import { number } from '@storybook/addon-knobs';
+import { boolean, number } from '@storybook/addon-knobs';
 
 import Pagination from '.';
 import SomethingToPage from './SomethingToPage';
@@ -19,15 +19,20 @@ import SomethingToPage from './SomethingToPage';
 <Props of={Pagination} />
 
 <Story name="Pagination with Knobs" parameters={{ docs: { disable: true } }}>
-  <SomethingToPage pageCount={number('pageCount', 10)}>
+  <SomethingToPage
+    canNext={boolean('canNextPage', true)}
+    canPrev={boolean('canPrevPage', true)}
+    initialPage={number('currentPage', 1)}
+    pageCount={number('pageCount', 10)}
+  >
     <Pagination
       canNextPage={true}
       canPreviousPage={true}
       currentPage={1}
-      gotoPage={() => console.log('Navigate to a different page.')}
-      nextPage={() => console.log('Navigate up a page.')}
+      gotoPage={() => {}}
+      nextPage={() => {}}
       pageCount={10}
-      prevPage={() => console.log('Navigate down a page.')}
+      prevPage={() => {}}
     />
   </SomethingToPage>
 </Story>
@@ -37,7 +42,7 @@ import SomethingToPage from './SomethingToPage';
     <Pagination
       canNextPage={true}
       canPreviousPage={true}
-      currentPage={1}
+      currentPage={3}
       gotoPage={() => console.log('Navigate to a different page.')}
       nextPage={() => console.log('Navigate up a page.')}
       pageCount={10}

--- a/src/components/pagination/SomethingToPage.jsx
+++ b/src/components/pagination/SomethingToPage.jsx
@@ -1,18 +1,35 @@
-import React, { useState } from 'react';
+/* eslint-disable */
+import React, { useEffect, useState } from 'react';
 
-const SomethingToPage = ({ children, initialPage = 0, pageCount = 10 }) => {
+const SomethingToPage = ({
+  canNext = true,
+  canPrev = false,
+  children,
+  initialPage = 0,
+  pageCount = 10,
+}) => {
   const [currentPage, setPage] = useState(initialPage);
+  const [canPreviousPage, setCanPrev] = useState(canPrev);
+  const [canNextPage, setCanNext] = useState(canNext);
 
-  const canNextPage = currentPage < pageCount;
-  const canPreviousPage = currentPage > 0;
-  const gotoPage = page => {
+  useEffect(() => setPage(initialPage), [initialPage]);
+  useEffect(() => setCanPrev(canPrev), [canPrev]);
+  useEffect(() => setCanNext(canNext), [canNext]);
+
+  const prevPage = () => {
+    const page = currentPage > 1 ? currentPage - 1 : 1;
+
     setPage(page);
   };
-  const nextPage = () => setPage(currentPage + 1);
-  const prevPage = () => setPage(currentPage - 1);
+  const nextPage = () => {
+    const page = currentPage >= pageCount ? pageCount : currentPage + 1;
+
+    setPage(page);
+  };
+  const gotoPage = page => setPage(page);
 
   return React.Children.map(children, child => {
-    const childProps = {
+    return React.cloneElement(child, {
       canNextPage,
       canPreviousPage,
       currentPage,
@@ -20,10 +37,9 @@ const SomethingToPage = ({ children, initialPage = 0, pageCount = 10 }) => {
       nextPage,
       pageCount,
       prevPage,
-    };
-
-    return React.cloneElement(child, { ...childProps });
+    });
   });
 };
 
 export default SomethingToPage;
+/* eslint-disable */

--- a/src/components/pagination/__snapshots__/Pagination.spec.js.snap
+++ b/src/components/pagination/__snapshots__/Pagination.spec.js.snap
@@ -11,8 +11,10 @@ exports[`<Pagination /> render() renders the component 1`] = `
       className="ce-pagination__arrow"
     >
       <button
+        aria-label="Previous Page"
         disabled={false}
         onClick={[Function]}
+        title="Previous Page"
         type="button"
       >
         <SystemIcon
@@ -23,7 +25,7 @@ exports[`<Pagination /> render() renders the component 1`] = `
       </button>
     </li>
     <li
-      className="ce-pagination__number"
+      className="ce-pagination__number current-page"
       key="1"
     >
       <button
@@ -34,7 +36,7 @@ exports[`<Pagination /> render() renders the component 1`] = `
       </button>
     </li>
     <li
-      className="ce-pagination__number current-page"
+      className="ce-pagination__number"
       key="2"
     >
       <button
@@ -81,8 +83,10 @@ exports[`<Pagination /> render() renders the component 1`] = `
       className="ce-pagination__arrow"
     >
       <button
+        aria-label="Next Page"
         disabled={false}
         onClick={[Function]}
+        title="Next Page"
         type="button"
       >
         <SystemIcon

--- a/src/components/table/Table.jsx
+++ b/src/components/table/Table.jsx
@@ -96,7 +96,7 @@ const Table = ({
   data,
   pageSize,
   clickable,
-  rowFunction,
+  clickFn,
   selectable,
   selectionHeaderFn,
   selectionFn,
@@ -185,7 +185,7 @@ const Table = ({
               }`,
               ...row.getRowProps(),
               onClick: clickable
-                ? event => rowFunction(row.original, event)
+                ? event => clickFn(row.original, event)
                 : () => {},
             };
 
@@ -258,7 +258,7 @@ Table.propTypes = {
    * @param {row} object - The row object for this row of the table.
    * @param {event} object - The event triggered by the click on the row.
    */
-  rowFunction: PropTypes.func,
+  clickFn: PropTypes.func,
   /**
    * Adds a checkbox in the `<Table />`, as the first column.
    */
@@ -285,7 +285,7 @@ Table.defaultProps = {
   className: '',
   pageSize: 10,
   clickable: false,
-  rowFunction: () => {},
+  clickFn: () => {},
   selectable: false,
   selectionHeaderFn: () => {},
   selectionFn: () => {},

--- a/src/components/table/Table.jsx
+++ b/src/components/table/Table.jsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 /* eslint-disable react/jsx-props-no-spreading */
-/* eslint-disable prettier/prettier */
 import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
@@ -28,16 +27,16 @@ import './table.less';
 import { Checkbox } from '../form-controls/checkbox';
 import Pagination from '../pagination';
 
-/* eslint-disable react/display-name */
-/* eslint-disable react/prop-types */
 /**
  * A `useTable` compatible hook that will add a column of/for the checkbox. To be passed into the `useTable` hook.
  * @param {object} instance - a `useTable` instance object. It is not a class so much as a pile of arrays (of functions).
  */
 const useRowSelectComponent = (checkboxFunction = () => {}) => instance => {
   // visibleColumns (a property on the instance object) is an array of functions. Each of which will allow you to decorate some aspect of the columns. In our case, we are adding a checkbox to the beginning of each row.
-  instance.visibleColumns.push((decorators) => [
+  instance.visibleColumns.push(decorators => [
     // This object is a 'constructor' for a column in the table. `useTable` will use the `Header` and `Cell` properties to determine what to put in our column. In our case they are components, but they could be strings.
+    /* eslint-disable react/display-name */
+    /* eslint-disable react/prop-types */
     {
       id: 'selection',
       Header: ({ getToggleAllPageRowsSelectedProps }) => (
@@ -63,11 +62,11 @@ const useRowSelectComponent = (checkboxFunction = () => {}) => instance => {
         />
       ),
     },
+    /* eslint-enable react/prop-types */
+    /* eslint-enable react/display-name */
     ...decorators,
   ]);
 };
-/* eslint-enable react/display-name */
-/* eslint-enable react/prop-types */
 
 /**
  * `Tables` display information in a grid-like format of rows and columns. They organize information in a way that’s easy to scan, so that users can look for patterns and insights. Tables can contain interactive components (such as chips, buttons, or menus), non-interactive elements (such as badges).
@@ -132,18 +131,20 @@ const Table = ({
     className,
   );
 
+  const navToPage = pg => gotoPage(pg - 1);
+
   return (
     <>
       <div className={classes} {...getTableProps()}>
         {/* table header */}
         <div className="ce-table__header" role="rowgroup">
-          {headerGroups.map((headerGroup) => (
+          {headerGroups.map(headerGroup => (
             <div
               key={headerGroup.id}
               className="ce-table__header--group"
               {...headerGroup.getHeaderGroupProps()}
             >
-              {headerGroup.headers.map((column) => (
+              {headerGroup.headers.map(column => (
                 <div
                   key={column.id}
                   className="ce-table__heading"
@@ -158,18 +159,20 @@ const Table = ({
 
         {/* table body */}
         <div className="ce-table__body" {...getTableBodyProps()}>
-          {page.map((row) => {
+          {page.map(row => {
             prepareRow(row);
 
             const rowProps = {
-              className: `ce-table__row${row.isSelected ? ' ce-table__row--selected' : ''}`,
+              className: `ce-table__row${
+                row.isSelected ? ' ce-table__row--selected' : ''
+              }`,
               ...row.getRowProps(),
               onClick: clickable ? event => rowFunction(row, event) : () => {},
             };
 
             return (
               <div key={row.id} {...rowProps}>
-                {row.cells.map((cell) => (
+                {row.cells.map(cell => (
                   <div
                     key={cell.id}
                     className="ce-table__cell"
@@ -194,8 +197,11 @@ const Table = ({
         <Pagination
           canPreviousPage={canPreviousPage}
           canNextPage={canNextPage}
-          currentPage={pageIndex}
-          gotoPage={gotoPage}
+          currentPage={
+            /* Pagination expects currentPage to be 1-index, and react-table provides the number 0-indexed */
+            pageIndex + 1
+          }
+          gotoPage={navToPage}
           nextPage={nextPage}
           pageCount={pageCount}
           prevPage={previousPage}
@@ -258,3 +264,4 @@ Table.defaultProps = {
 };
 
 export default Table;
+/* eslint-enable react/jsx-props-no-spreading */

--- a/src/components/table/Table.stories.mdx
+++ b/src/components/table/Table.stories.mdx
@@ -25,7 +25,8 @@ import Table from '.';
     clickable={boolean('clickable', false)}
     rowFunction={(row, event) => console.log('From the row:\nrow', row, "\nevent", event)}
     selectable={boolean('selectable', false)}
-    checkboxFunction={(row, event) => console.log('From the checkbox:\nrow', row, "\nevent", event)}
+    selectionHeaderFn={(rows, event) => console.log('From the header checkbox:\nrows', rows, "\nevent", event)}
+    selectionFn={(row, event) => console.log('From the checkbox:\nrow', row, "\nevent", event)}
   />
 </Story>
 
@@ -65,7 +66,7 @@ When a user hovers over a row, that row displays a background color.
 
 When a row checkbox is selected, the row displays a background color. For users who use screen magnification, the background color fill provides a way to indicate that a row has been selected, as the selected checkbox may appear outside of the magnified screen area.
 
-A checkbox can trigger an (optional) function, `checkboxFunction`, on click: `function(row, event) {}`.
+The checkbox in the header can trigger an (optional) function, `selectionHeaderFn`, on click: `function(rows, event) {}`. A checkbox in the body of the table can trigger an (optional) function, `selectionFn`, on click: `function(row, event) {}`.
 
 Note: If you have both a `checkboxFunction` and a `rowFunction`, when you click the checkbox, both functions will trigger.
 

--- a/src/test/__snapshots__/storyshots.test.js.snap
+++ b/src/test/__snapshots__/storyshots.test.js.snap
@@ -1090,8 +1090,10 @@ exports[`Storyshots Components/Atoms/Pagination Pagination 1`] = `
       className="ce-pagination__arrow"
     >
       <button
+        aria-label="Previous Page"
         disabled={false}
         onClick={[Function]}
+        title="Previous Page"
         type="button"
       >
         <span
@@ -1118,7 +1120,7 @@ exports[`Storyshots Components/Atoms/Pagination Pagination 1`] = `
       </button>
     </li>
     <li
-      className="ce-pagination__number current-page"
+      className="ce-pagination__number"
     >
       <button
         onClick={[Function]}
@@ -1128,7 +1130,7 @@ exports[`Storyshots Components/Atoms/Pagination Pagination 1`] = `
       </button>
     </li>
     <li
-      className="ce-pagination__number"
+      className="ce-pagination__number current-page"
     >
       <button
         onClick={[Function]}
@@ -1161,8 +1163,10 @@ exports[`Storyshots Components/Atoms/Pagination Pagination 1`] = `
       className="ce-pagination__arrow"
     >
       <button
+        aria-label="Next Page"
         disabled={false}
         onClick={[Function]}
+        title="Next Page"
         type="button"
       >
         <span
@@ -1190,11 +1194,13 @@ exports[`Storyshots Components/Atoms/Pagination Pagination with Knobs 1`] = `
     className="ce-pagination__container"
   >
     <li
-      className="ce-pagination__arrow ce-arrow--disabled"
+      className="ce-pagination__arrow"
     >
       <button
-        disabled={true}
+        aria-label="Previous Page"
+        disabled={false}
         onClick={[Function]}
+        title="Previous Page"
         type="button"
       >
         <span
@@ -1264,8 +1270,10 @@ exports[`Storyshots Components/Atoms/Pagination Pagination with Knobs 1`] = `
       className="ce-pagination__arrow"
     >
       <button
+        aria-label="Next Page"
         disabled={false}
         onClick={[Function]}
+        title="Next Page"
         type="button"
       >
         <span
@@ -3132,8 +3140,10 @@ Array [
         className="ce-pagination__arrow ce-arrow--disabled"
       >
         <button
+          aria-label="Previous Page"
           disabled={true}
           onClick={[Function]}
+          title="Previous Page"
           type="button"
         >
           <span
@@ -3203,8 +3213,10 @@ Array [
         className="ce-pagination__arrow"
       >
         <button
+          aria-label="Next Page"
           disabled={false}
           onClick={[Function]}
+          title="Next Page"
           type="button"
         >
           <span
@@ -4669,8 +4681,10 @@ Array [
         className="ce-pagination__arrow ce-arrow--disabled"
       >
         <button
+          aria-label="Previous Page"
           disabled={true}
           onClick={[Function]}
+          title="Previous Page"
           type="button"
         >
           <span
@@ -4740,8 +4754,10 @@ Array [
         className="ce-pagination__arrow"
       >
         <button
+          aria-label="Next Page"
           disabled={false}
           onClick={[Function]}
+          title="Next Page"
           type="button"
         >
           <span
@@ -5482,8 +5498,10 @@ Array [
         className="ce-pagination__arrow ce-arrow--disabled"
       >
         <button
+          aria-label="Previous Page"
           disabled={true}
           onClick={[Function]}
+          title="Previous Page"
           type="button"
         >
           <span
@@ -5553,8 +5571,10 @@ Array [
         className="ce-pagination__arrow"
       >
         <button
+          aria-label="Next Page"
           disabled={false}
           onClick={[Function]}
+          title="Next Page"
           type="button"
         >
           <span
@@ -7019,8 +7039,10 @@ Array [
         className="ce-pagination__arrow ce-arrow--disabled"
       >
         <button
+          aria-label="Previous Page"
           disabled={true}
           onClick={[Function]}
+          title="Previous Page"
           type="button"
         >
           <span
@@ -7090,8 +7112,10 @@ Array [
         className="ce-pagination__arrow"
       >
         <button
+          aria-label="Next Page"
           disabled={false}
           onClick={[Function]}
+          title="Next Page"
           type="button"
         >
           <span


### PR DESCRIPTION
This pull request:

- Updates the arguments passed to the callback function in the checkbox in a row in the `<Table />`

Currently the first parameter is the row object that `useTable` returns. It will be updated to the data that makes up that row. The second parameter is still the event.

- Renames the optional functions associated with `clickable` and `selectable` interactivity to reflect the interaction that they are associated with
  - `rowFunction` becomes `clickFn`
  - `checkboxFunction` becomes `selectionFn`
- Adds a prop for a callback that is attached to the checkbox in the head of the `<Table />`
  - `function(rows, event) {}`
- Updates Pagination component `goToPage` function, and `currentPage` props to be 1-indexed

Currently the `goToPage` function, and `currentPage` props assume a 0-indexed input. That is dues to initial constraints on the pagination that is built into the table. Those constraints have been accommodated, and the more natural 1-index will be the norm for the `<Pagination />` component.

- Fixes (lack of) accessibility on the prev/next arrows in `<Pagination />`