### PR TITLE
Accessiblilty and Testing Fixes

### DIFF
--- a/src/components/circular-loader/CircularLoader.jsx
+++ b/src/components/circular-loader/CircularLoader.jsx
@@ -73,7 +73,12 @@ const CircularLoader = ({
   return (
     <>
       <div className={classes}>
-        <svg viewBox={circleConfig.viewBox}>
+        <svg
+          viewBox={circleConfig.viewBox}
+          role="img"
+          aria-labelledby="ce-cl-title"
+        >
+          <title id="ce-cl-title">Circular Loader</title>
           <defs>
             <filter id="shadow">
               <feDropShadow

--- a/src/components/icon/ProductIcon.jsx
+++ b/src/components/icon/ProductIcon.jsx
@@ -28,7 +28,7 @@ import './icon.less';
 /** Bold icons are used with a gradient background circle.
  * These icons can be actionable or used as a static element.
  */
-const ProductIcon = ({ className, name, size }) => {
+const ProductIcon = ({ className, name, size, title }) => {
   const classes = cx(
     'ce-icon',
     'ce-icon__product',
@@ -40,7 +40,8 @@ const ProductIcon = ({ className, name, size }) => {
 
   return (
     <span className={classes}>
-      <svg className="ce-icon--white">
+      <svg aria-hidden={!title} className="ce-icon--white" role="img">
+        <title>{title || name}</title>
         <use xlinkHref={`#icons_product-${name}`} />
       </svg>
     </span>
@@ -87,11 +88,21 @@ ProductIcon.propTypes = {
    */
   // size: PropTypes.oneOf(SIZES),
   size: PropTypes.oneOf(['small', 'large', 'jumbo']),
+  /**
+   * By default, we hide ProductIcons from assitive technologies,
+   * such as screen readers, because there should be useful text
+   * associated with most icons.
+   *
+   * If you need to use an icon with no text, just add a descriptive title,
+   * and the icon will no longer be hidden from those technologies.
+   */
+  title: PropTypes.string,
 };
 
 ProductIcon.defaultProps = {
   className: '',
   size: 'small',
+  title: '',
 };
 
 export default ProductIcon;

--- a/src/components/icon/SecondaryIcon.jsx
+++ b/src/components/icon/SecondaryIcon.jsx
@@ -68,7 +68,7 @@ function nameOrText(props, propName, componentName = 'SecondaryIcon') {
  * These light icons are mostly used as an actionable element.
  * Alternatively, they can be used as avatars or indicators with two varying gradient options.
  */
-const SecondaryIcon = ({ className, color, name, size, text }) => {
+const SecondaryIcon = ({ className, color, name, size, text, title }) => {
   /* eslint-disable prettier/prettier */
   const classes = cx(
     'ce-icon',
@@ -86,7 +86,8 @@ const SecondaryIcon = ({ className, color, name, size, text }) => {
 
     if (name) {
       contents = (
-        <svg className="ce-icon--white">
+        <svg aria-hidden={!title} className="ce-icon--white" role="img">
+          <title>{title || name}</title>
           <use xlinkHref={`#icons_secondary-${name}`} />
         </svg>
       );
@@ -125,6 +126,15 @@ SecondaryIcon.propTypes = {
    * Up to 2 characters you would like in the `<SecondaryIcon />`, rather than a predefined one.
    */
   text: nameOrText,
+  /**
+   * By default, we hide SecondaryIcons from assitive technologies,
+   * such as screen readers, because there should be useful text
+   * associated with most icons.
+   *
+   * If you need to use an icon with no text, just add a descriptive title,
+   * and the icon will no longer be hidden from those technologies.
+   */
+  title: PropTypes.string,
 };
 
 SecondaryIcon.defaultProps = {
@@ -133,6 +143,7 @@ SecondaryIcon.defaultProps = {
   name: '',
   size: 'small',
   text: '',
+  title: '',
 };
 
 export default SecondaryIcon;

--- a/src/components/icon/SystemIcon.jsx
+++ b/src/components/icon/SystemIcon.jsx
@@ -29,7 +29,7 @@ import './icon.less';
  * System icons are designed to be simple, modern and friendly.
  * Each icon is reduced to its minimal form, expressing essential characteristics within the interface.
  */
-const SystemIcon = ({ className, color, name, size }) => {
+const SystemIcon = ({ className, color, name, size, title }) => {
   const classes = cx(
     'ce-icon',
     'ce-icon__system',
@@ -41,7 +41,12 @@ const SystemIcon = ({ className, color, name, size }) => {
 
   return (
     <span className={classes}>
-      <svg className={color && `ce-icon--${color}`}>
+      <svg
+        aria-hidden={!title}
+        className={color && `ce-icon--${color}`}
+        role="img"
+      >
+        <title>{title || name}</title>
         <use xlinkHref={`#icons_system-${name}`} />
       </svg>
     </span>
@@ -99,12 +104,22 @@ SystemIcon.propTypes = {
    */
   // size: PropTypes.oneOf(SIZES),
   size: PropTypes.oneOf(['small', 'large', 'jumbo']),
+  /**
+   * By default, we hide SystemIcons from assitive technologies,
+   * such as screen readers, because there should be useful text
+   * associated with most icons.
+   *
+   * If you need to use an icon with no text, just add a descriptive title,
+   * and the icon will no longer be hidden from those technologies.
+   */
+  title: PropTypes.string,
 };
 
 SystemIcon.defaultProps = {
   className: '',
   color: '',
   size: 'large',
+  title: '',
 };
 
 export default SystemIcon;

--- a/src/components/modal/Modal.jsx
+++ b/src/components/modal/Modal.jsx
@@ -120,7 +120,12 @@ const Modal = ({
           type="button"
           aria-label="Close"
         >
-          <SystemIcon color="black" name="close" size="jumbo" />
+          <SystemIcon
+            color="black"
+            name="close"
+            size="jumbo"
+            title="Close Modal"
+          />
         </button>
         <Container className="ce-modal__container" gap="padding">
           <h4 className="ce-modal__header">{title}</h4>

--- a/src/components/modal/index.js
+++ b/src/components/modal/index.js
@@ -1,3 +1,5 @@
-import Modal from './Modal';
+import Modal, { ModalDocs as MockModal } from './Modal';
 
 export default Modal;
+
+export { MockModal };

--- a/src/index.js
+++ b/src/index.js
@@ -17,7 +17,7 @@ import {
 } from './components/form-controls';
 import { ProductIcon, SecondaryIcon, SystemIcon } from './components/icon';
 import Link from './components/link';
-import Modal from './components/modal';
+import Modal, { MockModal } from './components/modal';
 import Pagination from './components/pagination';
 import Search from './components/search';
 import Switch from './components/switch';
@@ -53,4 +53,5 @@ export {
   Table,
   ToggleButton,
   ToggleButtonGroup,
+  MockModal,
 };


### PR DESCRIPTION
This pull request:

- clarifies the rules for accessibility for the icons
- corrects the accessibility issues for the close modal icon
- exports a modal that does not include `react-modal`'s `.setAppElement`

The new modal export can be used as a mocked modal in your unit tests.